### PR TITLE
Create Dockerfile with useful CI tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:12-alpine
+
+RUN apk add --no-cache --update git openssh-client make \
+    curl groff less python3 && \
+    pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir awscli~=1.18

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Countingup
+Copyright (c) 2020 Counting Limited
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-# docker-node
-Minimal node:12-alpine base image with a few tools useful in CI jobs
+# node
+
+[![Docker Automated build](https://img.shields.io/docker/build/countingup/node.svg)](https://hub.docker.com/r/countingup/node/builds/)
+
+Minimal node:12-alpine base image with a few tools useful in CI jobs.
+
+Includes:
+ - git
+ - ssh client
+ - GNU make
+ - AWS cli


### PR DESCRIPTION
NB. this is a public repo licensed as MIT.

The Dockerfile is based off of node:12-alpine and then has a number of extra packages installed that are required by CI build jobs.