### PR TITLE
Add an image variant including the expo-cli

### DIFF
--- a/Dockerfile-expocli
+++ b/Dockerfile-expocli
@@ -1,0 +1,3 @@
+FROM countingup/node:12
+
+RUN yarn global add expo-cli && yarn cache clean

--- a/README.md
+++ b/README.md
@@ -12,3 +12,5 @@ Includes:
  - lftp
  - GNU make
  - AWS cli
+
+Image variants tagged with 12-expocli also include a globally added expo-cli.


### PR DESCRIPTION
expo-cli doubles the size of the image so not adding it to the default image, but this is a useful tool to have for expo projects.
Docker hub is configured to build this 2nd dockerfile with the tag 12-expocli.