### PR TITLE
Add jq to expocli variant of image

### DIFF
--- a/Dockerfile-expocli
+++ b/Dockerfile-expocli
@@ -1,3 +1,4 @@
 FROM countingup/node:12
 
+RUN apk add --no-cache --update jq
 RUN yarn global add expo-cli && yarn cache clean

--- a/README.md
+++ b/README.md
@@ -13,4 +13,6 @@ Includes:
  - GNU make
  - AWS cli
 
-Image variants tagged with 12-expocli also include a globally added expo-cli.
+Image variants tagged with 12-expocli also include:
+ - a globally added expo-cli
+ - jq


### PR DESCRIPTION
Expo builds frequently require some json manipulation, so adding jq as a useful utility.