### PR TITLE
added zip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:12-alpine
 
-RUN apk add --no-cache --update git openssh-client make bash lftp coreutils \
+RUN apk add --no-cache --update git openssh-client make bash lftp coreutils zip \
     curl groff less python3 && \
     pip3 install --no-cache-dir --upgrade pip && \
     pip3 install --no-cache-dir awscli~=1.18

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Includes:
  - lftp
  - GNU make
  - AWS cli
+ - zip
 
 Image variants tagged with 12-expocli also include:
  - a globally added expo-cli


### PR DESCRIPTION
AWS Lambdas need to be `zip`ped, not tar + gzipped or similar. The build nodes for JS projects use this image and it doesn't have `zip` so that's bad times.