### PR TITLE
Build and deploy image using Semaphore

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,4 +1,3 @@
-# Generated from repo-toolkit docker-templates -- DO NOT EDIT MANUALLY
 #
 # CI pipeline for building the countingup/node Docker image and pushing to Docker Hub
 #
@@ -19,6 +18,8 @@ blocks:
         - name: Build and deploy image
           commands:
             - checkout
-            - docker build -t countingup/node .
+            - docker build -t countingup/node:12 .
+            - docker build -t countingup/node:12-expocli Dockerfile-expocli
             - echo "${DOCKERHUB_PASSWORD}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin
-            - docker push countingup/node
+            - docker push countingup/node:12
+            - docker push countingup/node:12-expocli

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,24 @@
+# Generated from repo-toolkit docker-templates -- DO NOT EDIT MANUALLY
+#
+# CI pipeline for building the countingup/node Docker image and pushing to Docker Hub
+#
+name: Build and deploy image
+version: v1.0
+
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+
+blocks:
+  - name: Build and deploy image
+    task:
+      secrets:
+        - name: countingup-dockerhub
+      jobs:
+        - name: Build and deploy image
+          commands:
+            - checkout
+            - docker build -t countingup/node .
+            - echo "${DOCKERHUB_PASSWORD}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin
+            - docker push countingup/node

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:12-alpine
 
+LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-node"
+
 RUN apk add --no-cache --update git openssh-client make bash lftp coreutils zip jq \
     curl groff less python3 && \
     pip3 install --no-cache-dir --upgrade pip && \

--- a/Dockerfile-expocli
+++ b/Dockerfile-expocli
@@ -1,4 +1,6 @@
 FROM countingup/node:12
 
+LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-node"
+
 RUN apk add --no-cache --update jq
 RUN yarn global add expo-cli && yarn cache clean

--- a/Dockerfile-expocli
+++ b/Dockerfile-expocli
@@ -1,6 +1,7 @@
 FROM countingup/node:12
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-node"
+LABEL io.snyk.containers.image.dockerfile="/Dockerfile-expocli"
 
 RUN apk add --no-cache --update jq
 RUN yarn global add expo-cli && yarn cache clean


### PR DESCRIPTION
Use Semaphore to build the image and push to Docker Hub. Replaces Docker Hub's Autobuild, which is becoming unavailable
on the free account tier.

Also add a label to the image that Snyk can use to monitor the repo.

[ch982]
