### PR TITLE
Update to build node for 14 and 16

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -22,7 +22,7 @@ blocks:
           commands:
             - checkout
             - docker build --build-arg NODE_VERSION -t countingup/node:${NODE_VERSION} .
-            - docker build --build-arg -t countingup/node:${NODE_VERSION}-expocli -f Dockerfile-expocli .
+            - docker build --build-arg NODE_VERSION -t countingup/node:${NODE_VERSION}-expocli -f Dockerfile-expocli .
             - echo "${DOCKERHUB_PASSWORD}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin
             - docker push countingup/node:${NODE_VERSION}
             - docker push countingup/node:${NODE_VERSION}-expocli

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -16,10 +16,13 @@ blocks:
         - name: countingup-dockerhub
       jobs:
         - name: Build and deploy image
+          matrix:
+            - env_var: NODE_VERSION
+              values: ["12", "14", "16"]
           commands:
             - checkout
-            - docker build -t countingup/node:12 .
-            - docker build -t countingup/node:12-expocli -f Dockerfile-expocli .
+            - docker build --build-arg NODE_VERSION -t countingup/node:${NODE_VERSION} .
+            - docker build --build-arg -t countingup/node:${NODE_VERSION}-expocli -f Dockerfile-expocli .
             - echo "${DOCKERHUB_PASSWORD}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin
-            - docker push countingup/node:12
-            - docker push countingup/node:12-expocli
+            - docker push countingup/node:${NODE_VERSION}
+            - docker push countingup/node:${NODE_VERSION}-expocli

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:12-alpine3.14
+ARG NODE_VERSION=16
+FROM node:${NODE_VERSION}-alpine3.15
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-node"
 

--- a/Dockerfile-expocli
+++ b/Dockerfile-expocli
@@ -1,4 +1,5 @@
-FROM countingup/node:12
+ARG NODE_VERSION=16
+FROM countingup/node:${NODE_VERSION}
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-node"
 LABEL io.snyk.containers.image.dockerfile="/Dockerfile-expocli"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/countingup/node.svg)](https://hub.docker.com/r/countingup/node/builds/) ![Docker Image Size](https://img.shields.io/docker/image-size/countingup/node/12)
 
-Minimal node:12-alpine base image with a few tools useful in CI jobs.
+Minimal node:12-alpine / node:14-alpine / node:16-alpine base image with a few tools useful in CI jobs.
 
 Includes:
  - bash


### PR DESCRIPTION
This adds the ability to build for node 14 and 16 and also updates alpine to 3.15