### PR TITLE
Remove creation of node 12 and 14 images

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,7 +18,7 @@ blocks:
         - name: Build and deploy image
           matrix:
             - env_var: NODE_VERSION
-              values: ["12", "14", "16"]
+              values: ["16"]
           commands:
             - checkout
             - docker build --build-arg NODE_VERSION -t countingup/node:${NODE_VERSION} .

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/countingup/node.svg)](https://hub.docker.com/r/countingup/node/builds/) ![Docker Image Size](https://img.shields.io/docker/image-size/countingup/node/12)
 
-Minimal node:12-alpine / node:14-alpine / node:16-alpine base image with a few tools useful in CI jobs.
+Minimal node:16-alpine base image with a few tools useful in CI jobs.
 
 Includes:
  - bash
@@ -15,11 +15,12 @@ Includes:
  - zip
  - jq
 
-Image variants tagged with 12-expocli also include:
+Image variants tagged with 16-expocli also include:
  - a globally added expo-cli
 
 ## Changelog
 
+- 2022-07-12 -- Remove builds of 12 and 14
 - 2022-07-04 -- Rebuild to update base image for security vulns
 - 2022-06-16 -- Rebuild to update base image for security vulns
 - 2022-05-16 -- Rebuild to update expo-cli 5.4.4


### PR DESCRIPTION
We've now migrated all projects to be using node 16 and stopped using the v12 an v14 images in our CI. 

We can now stop building those versions and stop having to handle the maintenance burden that they've added to our security processes. 

I assume this will require us to either delete the published images and/or turn off the Snyk monitoring for those versions.