### PR TITLE
Upgrade libcrypto1.1 for security vulns (both images)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:${NODE_VERSION}-alpine3.15
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-node"
 
-RUN apk add --no-cache --update git openssh-client make bash lftp coreutils zip jq busybox \
+RUN apk add --no-cache --update --upgrade libcrypto1.1 git openssh-client make bash lftp coreutils zip jq busybox \
     curl groff less python3 py-pip && \
     pip3 install --no-cache-dir --upgrade pip && \
     pip3 install --no-cache-dir awscli~=1.18

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:${NODE_VERSION}-alpine3.15
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-node"
 
-RUN apk add --no-cache --update --upgrade libcrypto1.1 git openssh-client make bash lftp coreutils zip jq busybox \
+RUN apk add --no-cache --update --upgrade git openssh-client make bash lftp coreutils zip jq busybox \
     curl groff less python3 py-pip && \
     pip3 install --no-cache-dir --upgrade pip && \
     pip3 install --no-cache-dir awscli~=1.18

--- a/Dockerfile-expocli
+++ b/Dockerfile-expocli
@@ -4,5 +4,5 @@ FROM countingup/node:${NODE_VERSION}
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-node"
 LABEL io.snyk.containers.image.dockerfile="/Dockerfile-expocli"
 
-RUN apk add --no-cache --update jq
+RUN apk add --no-cache --update --upgrade libcrypto1.1 jq
 RUN yarn global add expo-cli && yarn cache clean

--- a/Dockerfile-expocli
+++ b/Dockerfile-expocli
@@ -4,5 +4,5 @@ FROM countingup/node:${NODE_VERSION}
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-node"
 LABEL io.snyk.containers.image.dockerfile="/Dockerfile-expocli"
 
-RUN apk add --no-cache --update --upgrade libcrypto1.1 jq
+RUN apk add --no-cache --update jq
 RUN yarn global add expo-cli && yarn cache clean

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Image variants tagged with 16-expocli also include:
 
 ## Changelog
 
-- 2022-07-19 -- Upgrade libcrypto for security vulns
+- 2022-07-19 -- Upgrade packages to fix libcrypto1.1 security vulns
 - 2022-07-12 -- Remove builds of 12 and 14
 - 2022-07-04 -- Rebuild to update base image for security vulns
 - 2022-06-16 -- Rebuild to update base image for security vulns

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Image variants tagged with 16-expocli also include:
 
 ## Changelog
 
+- 2022-07-19 -- Upgrade libcrypto for security vulns
 - 2022-07-12 -- Remove builds of 12 and 14
 - 2022-07-04 -- Rebuild to update base image for security vulns
 - 2022-06-16 -- Rebuild to update base image for security vulns


### PR DESCRIPTION
This upgrades packages that depend on `libcrypto1.1`, which upgrades `libcrypto1.1` to the fix version `1.1.1q-r0` for the `node` image, and the `node-expocli` image which is based on the former.

This fixes https://www.cve.org/CVERecord?id=CVE-2022-2097 (https://security.snyk.io/vuln/SNYK-ALPINE315-OPENSSL-2941810 and https://security.snyk.io/vuln/SNYK-ALPINE315-OPENSSL-2941810)