### PR TITLE
Updating readme to force rebuild and resolve security vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,4 @@ Image variants tagged with 16-expocli also include:
 - 2021-11-16 -- Security fixes and latest expo-cli 4.13.0
 - 2021-11-06 -- Update to Alpine 3.14 base image
 - 2021-09-07 -- Security fixes and latest expo-cli 4.11.0
+- 2022-09-26 -- Rebuild to update base image for security vulnerability (expat/expat)


### PR DESCRIPTION
This PR will resolve the `expat/expat` vulnerabilities that were identified in `node:16` and `node:16-expocli`.  A fix already exists and the images just need to be rebuilt.

Building the `node` image locally and checking it with `snyk` returns 0 vulnerabilities.

<img width="827" alt="image" src="https://user-images.githubusercontent.com/109339874/192336205-89df2564-9f08-4df0-8c6b-4b4f8f3a4fbe.png">

Building the `node-expocli` image locally and checking it with `snyk` returns the `expat/expat` vulnerability.  This is only because the `Dockerfile` is referencing `countingup/node:16`.

<img width="1095" alt="image" src="https://user-images.githubusercontent.com/109339874/192335993-6f0c7c51-90de-40ef-8a57-4390809f037e.png">

Changing the base image in `Dockerfile-expocli` to reference the newly rebuilt node image that I used for testing returns 0 vulnerabilities when checked with `snyk`.

<img width="1095" alt="image" src="https://user-images.githubusercontent.com/109339874/192335770-4bf5a472-abab-4f6e-8ee7-ad124bfa83f9.png">
