### PR TITLE
Update for security vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Image variants tagged with 16-expocli also include:
 
 ## Changelog
 
+- 2022-12-07 -- Rebuild to update base image for security vulns
 - 2022-11-09 -- Rebuild to update base image for security vulns
 - 2022-11-03 -- Rebuild to update base image for security vulnerability (xmldom)
 - 2022-11-02 -- Rebuild to update base image for security vulnerability (curl/expat)


### PR DESCRIPTION
This should be installing a version of `qs` that's not affected by prototype pollution.

The Snyk Container command couldn't find the offending package after rebuilding the container, so this should be enough