### PR TITLE
Rebuild to update for security vulns (python3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Image variants tagged with 16-expocli also include:
 
 ## Changelog
 
+- 2022-12-12 -- Rebuild to update base image for security vulns (python3)
 - 2022-12-07 -- Rebuild to update base image for security vulns
 - 2022-11-09 -- Rebuild to update base image for security vulns
 - 2022-11-03 -- Rebuild to update base image for security vulnerability (xmldom)


### PR DESCRIPTION
Introduced through `python3/python3@3.9.15-r0`
Fixed in `python3/python3@3.9.16-r0`

```
...
✔ Tested 80 dependencies for known issues, no vulnerable paths found.

```