### PR TITLE
Rebuild to update base image for security vulns (openssl)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Image variants tagged with 16-expocli also include:
 
 ## Changelog
 
+- 2022-12-12 -- Rebuild to update base image for security vulns (openssl)
 - 2022-12-12 -- Rebuild to update base image for security vulns (python3)
 - 2022-12-07 -- Rebuild to update base image for security vulns
 - 2022-11-09 -- Rebuild to update base image for security vulns


### PR DESCRIPTION
Introduced through openssl/libssl3@3.0.7-r0, openssl/libcrypto3@3.0.7-r0 and others
Fixed in openssl/libssl3@3.0.7-r2