### PR TITLE
Update to Alpine 3.16 and node 16.19.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG NODE_VERSION=16
-FROM node:${NODE_VERSION}-alpine3.15
+FROM node:${NODE_VERSION}-alpine3.16
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-node"
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Image variants tagged with 16-expocli also include:
 
 ## Changelog
 
+- 2023-02-22 -- Update to Alpine 3.16 base image
 - 2023-02-20 -- Rebuild to update base image for security vulns
 - 2023-02-10 -- Rebuild to update base image for security vulns
 - 2022-12-12 -- Rebuild to update base image for security vulns (python3)


### PR DESCRIPTION
Fixes 3 HIGH and 6 MEDIUM CVEs by bumping the node version to 3.19.1