### PR TITLE
Rebuild for openssl vulnerabilities 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Image variants tagged with 16-expocli also include:
 
 ## Changelog
 
+- 2023-04-05 -- Rebuild to update base image for security vulns (openssl)
 - 2023-03-27 -- Rebuild to update base image for security vulns (openssl)
 - 2023-02-22 -- Update to Alpine 3.16 base image
 - 2023-02-20 -- Rebuild to update base image for security vulns


### PR DESCRIPTION
https://security.snyk.io/vuln/SNYK-ALPINE316-OPENSSL-5291792

This updates the `node-expocli` image to the latest `expo-cli` `6.3.2` which has subdependency `qs` at `6.5.2` 
 which introduces https://security.snyk.io/vuln/SNYK-JS-QS-3153490. This shouldn't be an issue and can be ignored when it is raised as this is a build time vulnerability so no impact.