### PR TITLE
Update libssl3 to fix CVE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:${NODE_VERSION}-alpine3.16
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-node"
 
-RUN apk add --no-cache --update --upgrade git openssh-client make bash lftp coreutils zip jq busybox \
+RUN apk add --no-cache --update --upgrade git openssh-client make bash lftp coreutils zip jq busybox libssl3 \
     curl groff less python3 py-pip && \
     pip3 install --no-cache-dir --upgrade pip && \
     pip3 install --no-cache-dir awscli~=1.18

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Image variants tagged with 16-expocli also include:
 
 |Date|Description|
 |-|-| 
+|2023-06-07|Rebuild to update base image for security vulns (libssl3)|
 |2023-05-31|Rebuild to update base image for security vulns|
 |2023-05-17|Rebuild to update base image for security vulns (openssh)|
 |2023-04-27|Rebuild to update base image for security vulns (git)|


### PR DESCRIPTION
https://security.snyk.io/vuln/SNYK-ALPINE316-OPENSSL-5661567