### PR TITLE
Remove libssl3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:${NODE_VERSION}-alpine3.16
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-node"
 
-RUN apk add --no-cache --update --upgrade git openssh-client make bash lftp coreutils zip jq busybox libssl3 \
+RUN apk add --no-cache --update --upgrade git openssh-client make bash lftp coreutils zip jq busybox \
     curl groff less python3 py-pip && \
     pip3 install --no-cache-dir --upgrade pip && \
     pip3 install --no-cache-dir awscli~=1.18

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Image variants tagged with 16-expocli also include:
 
 |Date|Description|
 |-|-| 
+|2023-06-08|Remove libssl3 (not required, added by mistake)|
 |2023-06-07|Rebuild to update base image for security vulns (libssl3)|
 |2023-05-31|Rebuild to update base image for security vulns|
 |2023-05-17|Rebuild to update base image for security vulns (openssh)|


### PR DESCRIPTION
This package was added by mistake in https://github.com/Countingup/docker-node/pull/45 when trying to fix https://security.snyk.io/vuln/SNYK-ALPINE316-OPENSSL-5661567.

The image just needed a rebuild to get the latest `libcrypto1.1` and `libssl1.1` (Snyk recommends at least `1.1.1u-r0`), but the previous PR also added:

```
libssl3-3.0.9-r0 x86_64 {openssl3} (Apache-2.0) [installed]
libcrypto3-3.0.9-r0 x86_64 {openssl3} (Apache-2.0) [installed]
```

by removing this package, the `libcrypto1.1` and `libssl1.1` will remain at sufficient versions to fix the CVE:

```
libssl1.1-1.1.1u-r1 x86_64 {openssl} (OpenSSL) [installed]
libcrypto1.1-1.1.1u-r1 x86_64 {openssl} (OpenSSL) [installed]
```
