### PR TITLE
Add build Node v18 image

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,7 +18,7 @@ blocks:
         - name: Build and deploy image
           matrix:
             - env_var: NODE_VERSION
-              values: ["16"]
+              values: ["16","18"]
           commands:
             - checkout
             - docker build --build-arg NODE_VERSION -t countingup/node:${NODE_VERSION} .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=16
+ARG NODE_VERSION=18
 FROM node:${NODE_VERSION}-alpine3.18
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-node"

--- a/Dockerfile-expocli
+++ b/Dockerfile-expocli
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=16
+ARG NODE_VERSION=18
 FROM countingup/node:${NODE_VERSION}
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-node"


### PR DESCRIPTION
Node v16 is reaching EOL on 2023-09-11. v18 is the next LTS version, supported until 2025-04-30.