### PR TITLE
Rebuild image to update `curl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Image variants tagged with 16-expocli also include:
 
 |Date|Description|
 |-|-| 
+|2023-09-27|Rebuild to update base image for security vulns (curl)|
 |2023-08-18|Rebuild to update base image for security vulns (node, openssl)|
 |2023-07-26|Rebuild to update base image for security vulns (openssl)|
 |2023-07-18|Update to Alpine 3.18 base image|


### PR DESCRIPTION
Tested locally by creating an updated image. `curl` vulnerability is not reported anymore.