### PR TITLE
Stop building image variant with expo-cli included

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -22,7 +22,5 @@ blocks:
           commands:
             - checkout
             - docker build --build-arg NODE_VERSION -t countingup/node:${NODE_VERSION} .
-            - docker build --build-arg NODE_VERSION -t countingup/node:${NODE_VERSION}-expocli -f Dockerfile-expocli .
             - echo "${DOCKERHUB_PASSWORD}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin
             - docker push countingup/node:${NODE_VERSION}
-            - docker push countingup/node:${NODE_VERSION}-expocli

--- a/Dockerfile-expocli
+++ b/Dockerfile-expocli
@@ -1,8 +1,0 @@
-ARG NODE_VERSION=18
-FROM countingup/node:${NODE_VERSION}
-
-LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-node"
-LABEL io.snyk.containers.image.dockerfile="/Dockerfile-expocli"
-
-RUN apk add --no-cache --update jq
-RUN yarn global add expo-cli && yarn cache clean

--- a/README.md
+++ b/README.md
@@ -15,13 +15,11 @@ Includes:
  - zip
  - jq
 
-Image variants tagged with 18-expocli also include:
- - a globally added expo-cli
-
 ## Changelog
 
 |Date|Description|
 |-|-| 
+|2023-11-13|Stop building image variant with expo-cli|
 |2023-10-13|Rebuild to update base image for security vulns (curl)|
 |2023-09-27|Rebuild to update base image for security vulns (curl)|
 |2023-08-18|Rebuild to update base image for security vulns (node, openssl)|


### PR DESCRIPTION
This removes the `docker-node` image variant that includes `expo-cli` as it is no longer needed.