### PR TITLE
Build expo-cli for node 16

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -22,5 +22,7 @@ blocks:
           commands:
             - checkout
             - docker build --build-arg NODE_VERSION -t countingup/node:${NODE_VERSION} .
+            - docker build --build-arg NODE_VERSION -t countingup/node:${NODE_VERSION}-expocli -f Dockerfile-expocli .
             - echo "${DOCKERHUB_PASSWORD}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin
             - docker push countingup/node:${NODE_VERSION}
+            - docker push countingup/node:${NODE_VERSION}-expocli

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,11 +18,20 @@ blocks:
         - name: Build and deploy image
           matrix:
             - env_var: NODE_VERSION
-              values: ["16","18"]
+              values: [ "18" ]
           commands:
             - checkout
             - docker build --build-arg NODE_VERSION -t countingup/node:${NODE_VERSION} .
-            - docker build --build-arg NODE_VERSION -t countingup/node:${NODE_VERSION}-expocli -f Dockerfile-expocli .
             - echo "${DOCKERHUB_PASSWORD}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin
             - docker push countingup/node:${NODE_VERSION}
-            - docker push countingup/node:${NODE_VERSION}-expocli
+        - name: Build and deploy legacy image
+            matrix:
+                - env_var: NODE_VERSION
+                  values: [ "16" ]
+            commands:
+              - checkout
+              - docker build --build-arg NODE_VERSION -t countingup/node:${NODE_VERSION} .
+              - docker build --build-arg NODE_VERSION -t countingup/node:${NODE_VERSION}-expocli -f Dockerfile-expocli .
+              - echo "${DOCKERHUB_PASSWORD}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin
+              - docker push countingup/node:${NODE_VERSION}
+              - docker push countingup/node:${NODE_VERSION}-expocli

--- a/Dockerfile-expocli
+++ b/Dockerfile-expocli
@@ -1,0 +1,8 @@
+ARG NODE_VERSION=18
+FROM countingup/node:${NODE_VERSION}
+
+LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-node"
+LABEL io.snyk.containers.image.dockerfile="/Dockerfile-expocli"
+
+RUN apk add --no-cache --update jq
+RUN yarn global add expo-cli && yarn cache clean

--- a/README.md
+++ b/README.md
@@ -15,13 +15,15 @@ Includes:
  - zip
  - jq
 
-Image variants tagged with 18-expocli also include:
+Image variants tagged with 16-expocli also include:
  - a globally added expo-cli
 
 ## Changelog
 
 |Date|Description|
-|-|-| 
+|-|-|
+|2023-11-15|Build v16 image variant with expo-cli|
+|2023-11-13|Stop building image variant with expo-cli|
 |2023-10-13|Rebuild to update base image for security vulns (curl)|
 |2023-09-27|Rebuild to update base image for security vulns (curl)|
 |2023-08-18|Rebuild to update base image for security vulns (node, openssl)|

--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ Includes:
  - zip
  - jq
 
+Image variants tagged with 18-expocli also include:
+ - a globally added expo-cli
+
 ## Changelog
 
 |Date|Description|
 |-|-| 
-|2023-11-13|Stop building image variant with expo-cli|
 |2023-10-13|Rebuild to update base image for security vulns (curl)|
 |2023-09-27|Rebuild to update base image for security vulns (curl)|
 |2023-08-18|Rebuild to update base image for security vulns (node, openssl)|


### PR DESCRIPTION
This PR builds the expo-cli for v16 only