### PR TITLE
Stop building node v16 and variant with expo-cli

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,11 +18,9 @@ blocks:
         - name: Build and deploy image
           matrix:
             - env_var: NODE_VERSION
-              values: ["16","18"]
+              values: ["18"]
           commands:
             - checkout
             - docker build --build-arg NODE_VERSION -t countingup/node:${NODE_VERSION} .
-            - docker build --build-arg NODE_VERSION -t countingup/node:${NODE_VERSION}-expocli -f Dockerfile-expocli .
             - echo "${DOCKERHUB_PASSWORD}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin
             - docker push countingup/node:${NODE_VERSION}
-            - docker push countingup/node:${NODE_VERSION}-expocli

--- a/Dockerfile-expocli
+++ b/Dockerfile-expocli
@@ -1,8 +1,0 @@
-ARG NODE_VERSION=18
-FROM countingup/node:${NODE_VERSION}
-
-LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-node"
-LABEL io.snyk.containers.image.dockerfile="/Dockerfile-expocli"
-
-RUN apk add --no-cache --update jq
-RUN yarn global add expo-cli && yarn cache clean

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Image variants tagged with 18-expocli also include:
 
 |Date|Description|
 |-|-| 
+|2023-11-30|Stop building node v16 and expocli image|
 |2023-10-13|Rebuild to update base image for security vulns (curl)|
 |2023-09-27|Rebuild to update base image for security vulns (curl)|
 |2023-08-18|Rebuild to update base image for security vulns (node, openssl)|


### PR DESCRIPTION
We are no longer using node v16, so we no longer need to build images for that version. We are also no longer needing to bundle expo-cli with our node images so remove the creation of those variants. 