### PR TITLE
Update base image to alpine 3.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 ARG NODE_VERSION=18
-FROM node:${NODE_VERSION}-alpine3.18
+FROM node:${NODE_VERSION}-alpine3.20
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-node"
 
-RUN apk add --no-cache --update --upgrade git openssh-client make bash lftp coreutils zip jq busybox \
+RUN apk add --no-cache --update --upgrade git openssh-client make bash lftp coreutils zip jq \
     curl groff less python3 py-pip && \
-    pip3 install --no-cache-dir --upgrade pip && \
-    pip3 install --no-cache-dir awscli~=1.18
+    pip3 install --no-cache-dir --break-system-packages awscli~=1.18


### PR DESCRIPTION
There are no new updates being built for 3.18, so update to 3.20 to get new security updates.

The pip installed by this is more picky about updating system dependencies and refuses to install without the extra flag. Ideally we'd move to install the aws cli v2 which is a direct apk package, but this requires more care to ensure compatibility with CI scripts, so leaving as a v1 CLI for now.