### PR TITLE
Rebuild for curl sec vuln

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Image variants tagged with 18-expocli also include:
 
 | Date       | Description                                                           |
 |------------|-----------------------------------------------------------------------| 
-| 2024-07-26 | Rebuild to update base image for security vulns (curl)                 |
+| 2024-07-26 | Rebuild to update base image for security vulns (curl)                |
 | 2024-07-09 | Rebuild to update base image for security vulns (openssh)             |
 | 2024-06-19 | Rebuild to update base image for security vulns (yajl, busybox)       |
 | 2024-05-28 | Rebuild to update base image for security vulns (openssl, busybox)    |

--- a/README.md
+++ b/README.md
@@ -20,57 +20,58 @@ Image variants tagged with 18-expocli also include:
 
 ## Changelog
 
-|Date|Description|
-|-|-| 
-|2024-07-09|Rebuild to udpate base image for security vulns (openssh)|
-|2024-06-19|Rebuild to udpate base image for security vulns (yajl, busybox)|
-|2024-05-28|Rebuild to udpate base image for security vulns (openssl, busybox)|
-|2024-05-13|Rebuild to update base image for security vulns (node)|
-|2024-04-05|Rebuild to update base image for security vulns (node)|
-|2024-02-20|Rebuild to update base image for security vulns (node)|
-|2024-02-12|Rebuild to update base image for security vulns (expat)|
-|2024-01-31|Rebuild to update base image for security vulns (coreutils, openssl)|
-|2024-01-22|Rebuild to update base image for security vulns (sqlite)|
-|2024-01-04|Rebuild to update base image for security vulns (curl, openssh)|
-|2023-11-30|Stop building node v16 and expocli image|
-|2023-10-13|Rebuild to update base image for security vulns (curl)|
-|2023-09-27|Rebuild to update base image for security vulns (curl)|
-|2023-08-18|Rebuild to update base image for security vulns (node, openssl)|
-|2023-07-26|Rebuild to update base image for security vulns (openssl)|
-|2023-07-18|Update to Alpine 3.18 base image|
-|2023-07-07|Rebuild to update base image for security vulns (node)|
-|2023-06-29|Rebuild to update base image for security vulns (node)|
-|2023-06-08|Remove libssl3 (not required, added by mistake)|
-|2023-06-07|Rebuild to update base image for security vulns (libssl3)|
-|2023-05-31|Rebuild to update base image for security vulns|
-|2023-05-17|Rebuild to update base image for security vulns (openssh)|
-|2023-04-27|Rebuild to update base image for security vulns (git)|
-|2023-04-17|Rebuild to update base image for security vulns (curl)|
-|2023-04-05|Rebuild to update base image for security vulns (openssl)|
-|2023-03-27|Rebuild to update base image for security vulns (openssl)|
-|2023-02-22|Update to Alpine 3.16 base image|
-|2023-02-20|Rebuild to update base image for security vulns|
-|2023-02-10|Rebuild to update base image for security vulns|
-|2022-12-12|Rebuild to update base image for security vulns (python3)|
-|2022-12-07|Rebuild to update base image for security vulns|
-|2022-11-09|Rebuild to update base image for security vulns|
-|2022-11-03|Rebuild to update base image for security vulnerability (xmldom)|
-|2022-11-02|Rebuild to update base image for security vulnerability (curl/expat)|
-|2022-10-25|Rebuild to update base image for security vulnerability (git/git)|
-|2022-09-26|Rebuild to update base image for security vulnerability (expat/expat)|
-|2022-09-07|Rebuild to update base image for security vulns|
-|2022-07-19|Upgrade packages to fix libcrypto1.1 security vulns|
-|2022-07-12|Remove builds of 12 and 14|
-|2022-07-04|Rebuild to update base image for security vulns|
-|2022-06-16|Rebuild to update base image for security vulns|
-|2022-05-16|Rebuild to update expo-cli 5.4.4|
-|2022-04-05|Rebuild to update base image for security vulns|
-|2022-04-05|Security fixes|
-|2022-03-30|Rebuild to update base image for security vulns|
-|2022-03-23|Rebuild to update base image for security vulns|
-|2022-02-23|Rebuild to update base image for security vulns|
-|2022-02-08|Rebuild to update base image for security vulns|
-|2022-01-17|Rebuild to update base image for security vulns|
-|2021-11-16|Security fixes and latest expo-cli 4.13.0|
-|2021-11-06|Update to Alpine 3.14 base image|
-|2021-09-07|Security fixes and latest expo-cli 4.11.0|
+| Date       | Description                                                           |
+|------------|-----------------------------------------------------------------------| 
+| 2024-07-26 | Rebuild to update base image for security vulns (curl)                 |
+| 2024-07-09 | Rebuild to update base image for security vulns (openssh)             |
+| 2024-06-19 | Rebuild to update base image for security vulns (yajl, busybox)       |
+| 2024-05-28 | Rebuild to update base image for security vulns (openssl, busybox)    |
+| 2024-05-13 | Rebuild to update base image for security vulns (node)                |
+| 2024-04-05 | Rebuild to update base image for security vulns (node)                |
+| 2024-02-20 | Rebuild to update base image for security vulns (node)                |
+| 2024-02-12 | Rebuild to update base image for security vulns (expat)               |
+| 2024-01-31 | Rebuild to update base image for security vulns (coreutils, openssl)  |
+| 2024-01-22 | Rebuild to update base image for security vulns (sqlite)              |
+| 2024-01-04 | Rebuild to update base image for security vulns (curl, openssh)       |
+| 2023-11-30 | Stop building node v16 and expocli image                              |
+| 2023-10-13 | Rebuild to update base image for security vulns (curl)                |
+| 2023-09-27 | Rebuild to update base image for security vulns (curl)                |
+| 2023-08-18 | Rebuild to update base image for security vulns (node, openssl)       |
+| 2023-07-26 | Rebuild to update base image for security vulns (openssl)             |
+| 2023-07-18 | Update to Alpine 3.18 base image                                      |
+| 2023-07-07 | Rebuild to update base image for security vulns (node)                |
+| 2023-06-29 | Rebuild to update base image for security vulns (node)                |
+| 2023-06-08 | Remove libssl3 (not required, added by mistake)                       |
+| 2023-06-07 | Rebuild to update base image for security vulns (libssl3)             |
+| 2023-05-31 | Rebuild to update base image for security vulns                       |
+| 2023-05-17 | Rebuild to update base image for security vulns (openssh)             |
+| 2023-04-27 | Rebuild to update base image for security vulns (git)                 |
+| 2023-04-17 | Rebuild to update base image for security vulns (curl)                |
+| 2023-04-05 | Rebuild to update base image for security vulns (openssl)             |
+| 2023-03-27 | Rebuild to update base image for security vulns (openssl)             |
+| 2023-02-22 | Update to Alpine 3.16 base image                                      |
+| 2023-02-20 | Rebuild to update base image for security vulns                       |
+| 2023-02-10 | Rebuild to update base image for security vulns                       |
+| 2022-12-12 | Rebuild to update base image for security vulns (python3)             |
+| 2022-12-07 | Rebuild to update base image for security vulns                       |
+| 2022-11-09 | Rebuild to update base image for security vulns                       |
+| 2022-11-03 | Rebuild to update base image for security vulnerability (xmldom)      |
+| 2022-11-02 | Rebuild to update base image for security vulnerability (curl/expat)  |
+| 2022-10-25 | Rebuild to update base image for security vulnerability (git/git)     |
+| 2022-09-26 | Rebuild to update base image for security vulnerability (expat/expat) |
+| 2022-09-07 | Rebuild to update base image for security vulns                       |
+| 2022-07-19 | Upgrade packages to fix libcrypto1.1 security vulns                   |
+| 2022-07-12 | Remove builds of 12 and 14                                            |
+| 2022-07-04 | Rebuild to update base image for security vulns                       |
+| 2022-06-16 | Rebuild to update base image for security vulns                       |
+| 2022-05-16 | Rebuild to update expo-cli 5.4.4                                      |
+| 2022-04-05 | Rebuild to update base image for security vulns                       |
+| 2022-04-05 | Security fixes                                                        |
+| 2022-03-30 | Rebuild to update base image for security vulns                       |
+| 2022-03-23 | Rebuild to update base image for security vulns                       |
+| 2022-02-23 | Rebuild to update base image for security vulns                       |
+| 2022-02-08 | Rebuild to update base image for security vulns                       |
+| 2022-01-17 | Rebuild to update base image for security vulns                       |
+| 2021-11-16 | Security fixes and latest expo-cli 4.13.0                             |
+| 2021-11-06 | Update to Alpine 3.14 base image                                      |
+| 2021-09-07 | Security fixes and latest expo-cli 4.11.0                             |


### PR DESCRIPTION
- Fixed some spellings of 'update' from 'udpate', formatted table and added entry for this.
- Rebuild for curl sec vuln tested with snyk locally

Note: There are other vulns that are currently ignored WRT which are fixed by update to v20/22