### PR TITLE
Update aws-cli to 2.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,4 @@ FROM node:${NODE_VERSION}-alpine3.20
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-node"
 
 RUN apk add --no-cache --update --upgrade git openssh-client make bash lftp coreutils zip jq \
-    curl groff less python3 py-pip && \
-    pip3 install --no-cache-dir --break-system-packages awscli~=1.18
+    curl groff less aws-cli~=2.15

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ FROM node:${NODE_VERSION}-alpine3.20
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-node"
 
 RUN apk add --no-cache --update --upgrade git openssh-client make bash lftp coreutils zip jq \
-    curl groff less aws-cli~=2.15
+    curl groff less aws-cli


### PR DESCRIPTION
It is recommended to install the v2 cli with apk rather than with pip.

Latest version for alpine 3.20 is aws-cli 2.15.57-r0

[skip-sc][sc-27646]