### PR TITLE
Update image for security updates and remove unused packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG NODE_VERSION=22
-FROM node:${NODE_VERSION}-alpine3.22
+FROM node:${NODE_VERSION}-alpine3.23
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-node"
 
@@ -8,7 +8,6 @@ RUN apk add --no-cache --update --upgrade \
     openssh-client \
     make \
     bash \
-    lftp \
     coreutils \
     zip \
     jq \


### PR DESCRIPTION
`lftp` used to be needed for cache support, but semaphore changed this to a go binary in 2021/22 (https://github.com/semaphoreci/toolbox/pull/350) so it's no longer needed

alpine 3.22 has outdated python packages with security vulnerabilities (dependency of aws-cli). These are updated in 3.23, and this shouldn't cause any other build issues.
