### PR TITLE
Rebuild for security vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,7 @@ RUN apk add --no-cache --update --upgrade \
     jq \
     aws-cli \
     curl && \
+    # Installing twice to work around https://github.com/npm/cli/issues/9151 \
+    npm i -g npm@~11.11.0 && \
     npm i -g npm@^11.0.0 && \
     rm -rf /root/.npm/_cacache # clears npm cache to save some space


### PR DESCRIPTION
Note that the npm update is a bit weird.
This is related to [this issue](https://github.com/npm/cli/issues/9151) where the latest version fails to install out-of-the-box. Fixed [here](https://github.com/npm/cli/pull/9152), but as yet unreleased.
